### PR TITLE
prototype format diffs from api

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,0 +1,22 @@
+var colors = require('colors');
+
+var jsdiff = require('diff');
+
+
+function handleDiff(originalJavascript, formattedJavascript) {
+  var output = '';
+  var changes = jsdiff.diffLines(originalJavascript, formattedJavascript);
+  changes.forEach(function(part) {
+    var color = part.added ? 'green' :
+      part.removed ? 'red' : 'grey';
+    var prefix = part.added ? '+ ' :
+      part.removed ? '- ' : '  ';
+    var lines = part.value.trimRight('\n').split('\n');
+    lines.forEach(function(line) {
+      output += (prefix + line)[color] + '\n';
+    });
+  });
+  return output;
+}
+
+exports.handleDiff = handleDiff;

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,8 +1,16 @@
+var jsdiff = require('diff');
 var esformatter = require('esformatter');
 
 var config = require('./config.js');
+var diff = require('./diff.js');
 
 exports.format = function(js, options) {
   options = options || config.getConfig();
-  return esformatter.format(js, options);
+  var formatted = esformatter.format(js, options);
+  if (options.diff === 'raw') {
+    return jsdiff.diffLines(js, formatted);
+  } else if (options.diff === true || options.diff === 'formatted') {
+    return diff.handleDiff(js, formatted);
+  }
+  return formatted;
 };

--- a/lib/run.js
+++ b/lib/run.js
@@ -4,6 +4,7 @@ var path = require('path');
 var child_process = require('child_process');
 
 var _ = require('underscore');
+var diff = require('./diff.js');
 
 var jsfmt = require('./index');
 
@@ -51,43 +52,6 @@ if (argv.help || (!argv.format && !argv.search && !argv.rewrite)) {
   process.exit();
 }
 
-function diff(pathA, pathB, callback) {
-  child_process.exec([
-    'git', 'diff', '--ignore-space-at-eol', '--no-index', '--', pathA, pathB
-  ].join(' '), callback);
-}
-
-function handleDiff(fullPath, originalJavascript, formattedJavascript) {
-  if (fullPath == 'stdin') {
-    tmp.file(function(err, pathA, fdA) {
-      if (err)
-        throw err;
-      fs.writeSync(fdA, originalJavascript);
-
-      tmp.file(function(err, pathB, fdB) {
-        if (err)
-          throw err;
-        fs.writeSync(fdB, formattedJavascript);
-
-        diff(pathA, pathB, function(err, stdout, stderr) {
-          if (stdout) console.log(stdout);
-          if (stderr) console.log(stderr);
-        });
-      });
-    });
-  } else {
-    tmp.file(function(err, pathA, fdA) {
-      if (err)
-        throw err;
-      fs.writeSync(fdA, formattedJavascript);
-
-      diff(fullPath, pathA, function(err, stdout, stderr) {
-        if (stdout) console.log(stdout);
-        if (stderr) console.log(stderr);
-      });
-    });
-  }
-}
 
 function handleJavascript(fullPath, original) {
   var js = original;
@@ -144,7 +108,10 @@ function handleJavascript(fullPath, original) {
   }
 
   if (argv.diff) {
-    handleDiff(fullPath, original, js);
+    console.log(relativePath);
+    if (original != js) {
+      console.log(diff.handleDiff(original, js));
+    }
   } else if (argv.list && original != js) {
     // Print filenames who differ
     console.log(relativePath);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "underscore": "*",
     "tmp": "*",
     "minimist": "*",
-    "rc": "*"
+    "rc": "*",
+    "diff": "*",
+    "colors": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this is just a crazy prototype/idea I had when pondering #8

basically trying to expose the ability to run a diff from the api. currently the way the code is we would have to change the api to accept callbacks, so I decided to give it a shot without really changing the public facing api very much.

it can be used like:

``` javascript
var jsfmt = require('jsfmt');

var code = 'var test=require("test");if(1){test.test();}';

var config = jsfmt.getConfig();
config.diff = true;
var diff = jsfmt.format(code, config);
console.log(diff);
```

will output

``` diff
+ var test = require("test");
+ if (1) {
+   test.test();
+ }
- var test = require("test");if(1){test.test();}
```

`config.diff` can accept, `raw` (this is the raw response from the [diff](https://www.npmjs.org/package/diff) module), `formatted` (thinking maybe I should rename to 'pretty' or something better) or `true` which gives the above result (with '+', '-', etc and colors) or anything else will result in returning the normal just formatted output.

The main thing that we lose are that it isn't a true "diff" so you cannot create a patch from it. Also right now if the file has changed at all then it shows the changes for the whole file not just the changed plus some context.

so that all said, I think I am meh about this change, dont mind if it gets a :thumbsdown: and scrapped.
