### PR TITLE
stop rc from including minimist argv in the config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,11 +7,13 @@ var config = null;
 var loadConfig = function() {
   // attempt to pickup on indent level from existing .jshintrc file
   defaultStyle.indent = defaultStyle.indent || {};
+  // rc(name, default, argv), use {} to stop argv from being loaded
   var jshintSettings = rc('jshint', {}, {});
   if (jshintSettings.indent) {
     defaultStyle.indent.value = new Array(parseInt(jshintSettings.indent) + 1).join(' ');
   }
 
+  // rc(name, default, argv), use {} to stop argv from being loaded
   return rc('jsfmt', defaultStyle, {});
 };
 


### PR DESCRIPTION
we are getting `_` added to the `jsfmt` config, example:

``` javascript
var jsfmt = require("jsfmt");

console.dir(jsfmt.getConfig());
```

``` bash
$ node example.js some test stuff
{ preset: 'default',
  indent: 
   { value: '  ',
     TopLevelFunctionBlock: 1 },
  ...
  _: [ 'some', 'test', 'stuff' ] }
```
