### PR TITLE
add link to jsfmt.el emacs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Links
 
 - Atom Package - https://atom.io/packages/atom-jsfmt - "Automatically run jsfmt every time you save a javascript source file."
 - Grunt Task - https://github.com/james2doyle/grunt-jsfmt - "A task for the jsfmt library."
+- Emacs Plugin - https://github.com/brettlangdon/jsfmt.el - "Run jsfmt from within emacs"
 
 Changelog
 ---


### PR DESCRIPTION
finally had a chance to sit down and write an emacs plugin or really copy/paste the one from go-mode and make it work with jsfmt, but still.
