### PR TITLE
replace ^ with ~ for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "parser",
     "rewrite",
     "syntax",
-    "format"
+    "format",
+    "search"
   ],
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
carets are not supported by the version of npm which ships
with node < 0.10.16, using ~ adds the backwards compatibility

addresses #73
