### PR TITLE
show error with --json [--rewrite|--search]

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -37,6 +37,11 @@ var argv = docopt.docopt(doc, {
   version: 'jsfmt ' + info.version,
 });
 
+if (argv['--json'] && (argv['--rewrite'] || argv['--search'])) {
+  console.error('Rewriting/Searching is not supported for JSON');
+  process.exit(1);
+}
+
 function diff(pathA, pathB, callback) {
   child_process.exec([
     'git', 'diff', '--ignore-space-at-eol', '--no-index', '--', pathA, pathB


### PR DESCRIPTION
show "Rewriting/Searching is not supported for JSON" whenever you try to run

`jsfmt --json --rewrite` or `jsfmt --json --search`
