### PR TITLE
Exiting on error should return -1

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -39,7 +39,7 @@ var argv = docopt.docopt(doc, {
 
 if (argv['--json'] && (argv['--rewrite'] || argv['--search'])) {
   console.error('Rewriting/Searching is not supported for JSON');
-  process.exit(1);
+  process.exit(-1);
 }
 
 function diff(pathA, pathB, callback) {
@@ -142,7 +142,7 @@ function handleJavascript(fullPath, original) {
         var msg = util.format('Error: %s Line: %s Column: %s', error.description, error.lineNumber, error.column);
         console.log(msg);
       });
-      process.exit(1);
+      process.exit(-1);
     }
   }
 


### PR DESCRIPTION
This is the expected behavior for any cli application exiting in error - this will also match the behavior of gofmt.
