### PR TITLE
convert format to use regex replace for shebangs

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -8,16 +8,14 @@ exports.format = function(js, options) {
   var sheBang = null;
   // esformatter doesn't like shebangs
   // remove if one exists as the first line
-  if (js.indexOf('#!') === 0) {
-    var firstNewline = js.indexOf('\n');
-    sheBang = js.substring(0, firstNewline);
-    js = js.substring(firstNewline);
-  }
-
+  js = js.replace(/^#!.*\n/, function(match) {
+    sheBang = match;
+    return '';
+  }); 
   js = esformatter.format(js, options);
 
   // if we had a shebang, add back in
-  if (sheBang !== null) {
+  if (sheBang) {
     js = sheBang + js;
   }
 


### PR DESCRIPTION
indexOf will parse the entire string for `#1` while regex for beginning of string will fail-short if first chars don't match.
- Performance boost (more than 50% on large strings)
- Cleaner syntax
