### PR TITLE
Fix bug with --list for already formatted files

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -148,9 +148,11 @@ function handleJavascript(fullPath, original) {
 
   if (argv['--diff']) {
     handleDiff(fullPath, original, js);
-  } else if (argv['--list'] && original != js) {
+  } else if (argv['--list']) {
     // Print filenames who differ
-    console.log(relativePath);
+    if(original != js) {
+      console.log(relativePath);
+    }
   } else if (argv['--write']) {
     // Overwrite original file
     fs.writeFileSync(fullPath, js);


### PR DESCRIPTION
It's supposed to just output nothing if jsfmt would not modify the file.
It was cascading down to the final else, and dumping the file to STDOUT
instead.
