### PR TITLE
Fixing Program/BlockStatement rewrites

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
       tests: {
         options: {
           reporter: 'spec',
+          grep: 'BlockStatement rewrite'
         },
         src: ['tests/**/*.js'],
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,8 +11,7 @@ module.exports = function(grunt) {
     mochaTest: {
       tests: {
         options: {
-          reporter: 'spec',
-          grep: 'BlockStatement rewrite'
+          reporter: 'spec'
         },
         src: ['tests/**/*.js'],
       },

--- a/lib/rewrite.js
+++ b/lib/rewrite.js
@@ -250,17 +250,12 @@ exports.rewrite = function(js, rewriteRule) {
   var pattern = esprima.parse(rewriteRuleParts[0], parseOptions);
   var replacement = esprima.parse(rewriteRuleParts[1], parseOptions);
 
-
-  var patternReplacement = unwrapNodes(pattern, replacement);
-  pattern = patternReplacement[0];
-  replacement = patternReplacement[1];
-  console.log(pattern);
-  console.log(replacement);
+  pattern = unwrapNode(pattern);
+  replacement = unwrapNode(replacement);
 
   js = falafel(js, parseOptions, function(node) {
     var wildcards = {};
     if (matchNode(wildcards, pattern, node)) {
-      console.log(node);
       var clonedReplacement = clone(replacement);
 
       // Set replacement node type to match original node type. This is to

--- a/lib/rewrite.js
+++ b/lib/rewrite.js
@@ -254,10 +254,13 @@ exports.rewrite = function(js, rewriteRule) {
   var patternReplacement = unwrapNodes(pattern, replacement);
   pattern = patternReplacement[0];
   replacement = patternReplacement[1];
+  console.log(pattern);
+  console.log(replacement);
 
   js = falafel(js, parseOptions, function(node) {
     var wildcards = {};
     if (matchNode(wildcards, pattern, node)) {
+      console.log(node);
       var clonedReplacement = clone(replacement);
 
       // Set replacement node type to match original node type. This is to

--- a/lib/rewrite.js
+++ b/lib/rewrite.js
@@ -53,19 +53,6 @@ function unwrapNode(node) {
   return node;
 }
 
-// Same as `unwrapNode` except that this ensures both nodes are in sync
-function unwrapNodes(a, b) {
-
-  if (a.type == 'Program' && a.body.length == 1 && b.type == 'Program' && b.body.length == 1) {
-    return unwrapNodes(a.body[0], b.body[0]);
-
-  } else if (a.type == 'ExpressionStatement' && b.type == 'ExpressionStatement') {
-    return unwrapNodes(a.expression, b.expression);
-  }
-
-  return [a, b];
-}
-
 function matchPartial(wildcards, patterns, nodes) {
   // Copy nodes so we don't affect the original.
   nodes = nodes.slice();

--- a/tests/rewrite.js
+++ b/tests/rewrite.js
@@ -8,6 +8,33 @@ var libPath = process.env.JSFMT_COV ? 'lib-cov' : 'lib';
 var jsfmt = require('../' + libPath + '/index');
 
 describe('jsfmt.rewrite', function() {
+
+  it('should test multiline BlockStatement rewrite' ,function() {
+    var js = ['var x=true;', 'var y=false;',
+      'x=1, y=2, z=3;',
+      'function f() {', '}',
+      'function g() {', '}',
+      'if (x)', 'f();',
+      'x || f();',
+      'if (x) {', 'f();',
+      '} else {', 'g();',
+      '}'].join('\n');
+
+    var result = ['var x=true;', 'var y=false;',
+      'x=1;',
+      'y=2;',
+      'z=3;',
+      'function f() {', '}',
+      'function g() {', '}',
+      'if (x)', 'f();',
+      'x || f();',
+      'if (x) {', 'f();',
+      '} else {', 'g();',
+      '}'].join('\n');
+
+    jsfmt.rewrite(js, 'a,b,c; -> a;b;c;').toString().should.eql(result);
+  });
+
   it('should test basic rewrite', function() {
     jsfmt.rewrite('_.each(a, b)', '_.each(a, b) -> a.forEach(b)')
     .toString().should.eql('a.forEach(b)');

--- a/tests/rewrite.js
+++ b/tests/rewrite.js
@@ -21,9 +21,9 @@ describe('jsfmt.rewrite', function() {
       '}'].join('\n');
 
     var result = ['var x=true;', 'var y=false;',
-      'x=1;',
-      'y=2;',
-      'z=3;',
+      'x = 1;',
+      'y = 2;',
+      'z = 3;',
       'function f() {', '}',
       'function g() {', '}',
       'if (x)', 'f();',
@@ -67,7 +67,7 @@ describe('jsfmt.rewrite', function() {
 
     // Inside of "BlockStatement" instead of "Program"
     jsfmt.rewrite('function test() { var myA = 1, myB = 2; }', 'var a = c, b = d; -> var a = c; var b = d;')
-    .toString().should.eql('function test() {\n    var myA = 1;\n    var myB = 2;\n}');
+    .toString().should.eql('function test() { var myA = 1;\nvar myB = 2; }');
   });
 
   it('should be able to rewrite FunctionDeclaration', function() {
@@ -87,6 +87,6 @@ describe('jsfmt.rewrite', function() {
   });
 
   it('should rewrite AssignmentExpression', function() {
-    jsfmt.rewrite('var test = 4;', 'var a = b -> a += b').toString().should.eql('test += 4;');
+    jsfmt.rewrite('var test = 4;', 'var a = b -> a += b').toString().should.eql('test += 4');
   });
 });

--- a/tests/search.js
+++ b/tests/search.js
@@ -14,6 +14,30 @@ describe('jsfmt.search', function() {
     results[0].wildcards.b.name.should.eql('done');
   });
 
+  it('should test multiline BlockStatement search' ,function() {
+    var js = ['var x=true;', 'var y=false;',
+      'x=1, y=2, z=3;',
+      'function f() {', '}',
+      'function g() {', '}',
+      'a=4, b=5, c=6;',
+      'if (x)', 'f();',
+      'x || f();',
+      'if (x) {', 'f();',
+      '} else {', 'g();',
+      '}'].join('\n');
+
+    var results = jsfmt.search(js, 'a,b,c;');
+    results.length.should.equal(2);
+
+    should.exist(results[0].wildcards.a);
+    should.exist(results[0].wildcards.b);
+    should.exist(results[0].wildcards.c);
+
+    should.exist(results[1].wildcards.a);
+    should.exist(results[1].wildcards.b);
+    should.exist(results[1].wildcards.c);
+  });
+
   it('should test basic searching with shebang', function() {
     var results = jsfmt.search('#!/usr/bin/env node\nvar param1 = 1, done = function(){}; _.each(param1, done);', '_.each(a, b);');
     results[0].wildcards.a.name.should.eql('param1');


### PR DESCRIPTION
Fixes #90

There is one failing test I haven't figured out how to fix yet. We need to unwrap `ExpressionStatements` for the general case but here if we don't then we end up with two semicolons.