### PR TITLE
Use process.stdout.write instead of console.log to avoid outputting extra newline

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -184,7 +184,7 @@ function handleJavascript(fullPath, original) {
       }
     }
     // Print to stdout
-    console.log(js);
+    process.stdout.write(js);
   }
 }
 


### PR DESCRIPTION
This caused an endless growth of newlines at the end of the file when used with
editors such as vim that make sure files end with a newline. With this change,
the transformation is a noop when run a second time.