### PR TITLE
Bumping version to publish to npm for esformatter v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsfmt",
   "description": "gofmt for javascript",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "https://github.com/rdio/jsfmt",
   "main": "./lib/index.js",
   "engines": {
@@ -21,7 +21,7 @@
   "maintainers": [
     {
       "name": "Jim Fleming",
-      "email": "jim.fleming@rd.io"
+      "email": "jim@barkingmousestudio.com"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
I think this is just a patch version change since the API isn't changing even if the output is different.

Also updating the maintainer email address since the old address is invalid.