### PR TITLE
Allow overriding default plugins via .jsfmtrc

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,5 @@
 var rc = require('rc');
+var deepExtend = require('deep-extend');
 
 var defaultStyle = require('./defaultStyle.json');
 
@@ -14,7 +15,14 @@ var loadConfig = function() {
   }
 
   // rc(name, default, argv), use {} to stop argv from being loaded
-  return rc('jsfmt', defaultStyle, {});
+  var config = rc('jsfmt', {}, {});
+
+  //allow overriding the list of plugins via local config
+  if(config.plugins) {
+    defaultStyle.plugins = config.plugins;
+  }
+
+  return deepExtend(defaultStyle, config);
 };
 
 exports.getConfig = function() {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "falafel": "~0.3.1",
     "glob": "~4.0.0",
     "rc": "~0.5.0",
+    "deep-extend": "~0.2.5",
     "rocambole": "~0.3.3",
     "tmp": "~0.0.23",
     "underscore": "~1.6.0"


### PR DESCRIPTION
I needed to override the default list of plugins because the addition of `esformatter-var-each` to the default list led to rather widespread formatting changes in our project that we can't opt in to right now. I found that it wasn't possible to change the default list of plugins via `.jsfmtrc`, as I described on #125.

The `rc` module doesn't let you override array properties (like `plugins`) because it defaults to merging together the values if they are objects. This patch makes it possible to override the list of plugins via `.jsfmtrc`.

cc: @jish 