### PR TITLE
add showing help on if execute with no arguments

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -39,6 +39,11 @@ var argv = docopt.docopt(doc, {
   version: 'jsfmt ' + info.version,
 });
 
+if (argv['<file>'].length < 1) {
+  console.log(doc);
+  process.exit(-1);
+}
+
 if (argv['--json'] && (argv['--rewrite'] || argv['--search'])) {
   console.error('Rewriting/Searching is not supported for JSON');
   process.exit(-1);


### PR DESCRIPTION
Hello:D

When I specify no arguments(my bad:sweat_smile: ) for `jsfmt`, CLI does not respond.


```
$ jsfmt

//... no responce
```

What do you think showing help message in such a case like `jsfmt -h`?

```
$ jsfmt

Usage:
  jsfmt [--no-format] [--save-ast] [--diff|--list|--write] [--validate] [--rewrite PATTERN|--search PATTERN] [--json|--ast] [<file>...]
  jsfmt (--version | --help)

Options:
  -h --help                      Show this help text
  --version                      Show jsfmt version
  -d --diff                      Show diff against original file
  -l --list                      List the files which differ from jsfmt output
  -v --validate                  Validate the input file(s)
  --no-format                    Do not format the input file(s)
  -w --write                     Overwrite the original file with jsfmt output
  -j --json                      Tell jsfmt that the file being parsed is json
  -a --ast                       Tell jsfmt that the file being parsed is in JSON AST
  --save-ast                     Output the resulting js in JSON AST format
  -r=PATTERN --rewrite PATTERN   Rewrite rule (e.g., 'a.slice(b, len(a) -> a.slice(b)')
  -s=PATTERN --search PATTERN    Search rule (e.g., 'a.slice')
```