### PR TITLE
add showing help on if execute with no arguments

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -230,6 +230,9 @@ if (paths.length > 0) {
     var chunk = process.stdin.read();
     if (chunk !== null) {
       js += chunk;
+    } else if (chunk === null && js === ''){
+      console.log(doc);
+      process.exit(-1);
     }
   });
   process.stdin.on('end', function() {


### PR DESCRIPTION
fix #145 

showing help message in these case:
* empty argument
* empty stdin

@brettlangdon  How about this? Could you please review?

```
$ cat test-noargument.js
var a = function (a,b,c, d)
{
  return a+b+c+d;
}

$ cat test-noargument.js | ./bin/jsfmt
var a = function(a, b, c, d) {
  return a + b + c + d;
}

$ ./bin/jsfmt test-noargument.js
var a = function(a, b, c, d) {
  return a + b + c + d;
}

$ ./bin/jsfmt
Usage:
  jsfmt [--no-format] [--save-ast] [--diff|--list|--write] [--validate] [--rewrite PATTERN|--search PATTERN] [--json|--ast] [<file>...]
  jsfmt (--version | --help)

Options:
  -h --help                      Show this help text
  --version                      Show jsfmt version
  -d --diff                      Show diff against original file
  -l --list                      List the files which differ from jsfmt output
  -v --validate                  Validate the input file(s)
  --no-format                    Do not format the input file(s)
  -w --write                     Overwrite the original file with jsfmt output
  -j --json                      Tell jsfmt that the file being parsed is json
  -a --ast                       Tell jsfmt that the file being parsed is in JSON AST
  --save-ast                     Output the resulting js in JSON AST format
  -r=PATTERN --rewrite PATTERN   Rewrite rule (e.g., 'a.slice(b, len(a) -> a.slice(b)')
  -s=PATTERN --search PATTERN    Search rule (e.g., 'a.slice')
```