### PR TITLE
remove dependency on "harmony" branch in favor of esprima-fb

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1,5 +1,5 @@
 var escodegen = require('escodegen');
-var esprima = require('esprima');
+var esprima = require('esprima-fb');
 
 
 module.exports.parseAST = function(ast) {

--- a/lib/rewrite.js
+++ b/lib/rewrite.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var esprima = require('esprima');
+var esprima = require('esprima-fb');
 var falafel = require('falafel');
 var escodegen = require('escodegen');
 var _ = require('underscore');

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima');
+var esprima = require('esprima-fb');
 var helpers = require('./helpers');
 
 module.exports.validate = function(js) {

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     }
   ],
   "dependencies": {
+    "deep-extend": "~0.3.2",
     "docopt": "~0.4.0",
     "escodegen": "~1.6.1",
     "esformatter": "~0.5.0",
     "esformatter-braces": "~1.0.0",
     "esformatter-var-each": "~1.0.0",
-    "esprima": "jquery/esprima#harmony",
+    "esprima-fb": "15001.1.0-dev-harmony-fb",
     "falafel": "~0.3.1",
     "glob": "~4.4.0",
     "rc": "~0.6.0",
-    "deep-extend": "~0.3.2",
     "rocambole": "~0.5.0",
     "tmp": "~0.0.23",
     "underscore": "~1.8.0"


### PR DESCRIPTION
The replacement of the harmony branch is the 2.x series of the `esprima`
module. Unfortunately, it introduces breaking changes that cause this
module's tests to fail. Switching to `esprima-fb` as a stopgap measure
to fix currently failing builds in the meantime.