### PR TITLE
Write errors to error buffer

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -89,7 +89,7 @@ function handleDiff(fullPath, originalJavascript, formattedJavascript) {
           console.log(stdout);
         }
         if (stderr) {
-          console.log(stderr);
+          console.error(stderr);
         }
       });
     });
@@ -159,7 +159,7 @@ function handleJavascript(fullPath, original) {
     if (errors && errors.length) {
       errors.forEach(function(error) {
         var msg = util.format('Error: %s Line: %s Column: %s', error.description, error.lineNumber, error.column);
-        console.log(msg);
+        console.error(msg);
       });
       process.exit(-1);
     }


### PR DESCRIPTION
In some situations, errors were written to the output buffer.
Writing these to the error buffer (i.e. `console.error`) is better.