### PR TITLE
Set error state if there is any error

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -105,7 +105,7 @@ function handleJavascript(fullPath, original) {
       js = jsfmt.parseAST(JSON.parse(js));
     } catch ( err ) {
       console.error(relativePath, err.message);
-      return;
+      return false;
     }
   }
 
@@ -123,8 +123,9 @@ function handleJavascript(fullPath, original) {
       });
     } catch ( err ) {
       console.error(relativePath, err.message);
+      return false;
     }
-    return;
+    return true;
   }
 
   if (argv['--rewrite']) {
@@ -132,7 +133,7 @@ function handleJavascript(fullPath, original) {
       js = jsfmt.rewrite(js, argv['--rewrite']).toString();
     } catch ( err ) {
       console.error(relativePath, err);
-      return;
+      return false;
     }
   }
 
@@ -145,7 +146,7 @@ function handleJavascript(fullPath, original) {
       }
     } catch ( err ) {
       console.error(relativePath, err);
-      return;
+      return false;
     }
   }
 
@@ -161,7 +162,7 @@ function handleJavascript(fullPath, original) {
         var msg = util.format('Error: %s Line: %s Column: %s', error.description, error.lineNumber, error.column);
         console.log(msg);
       });
-      process.exit(-1);
+      return false;
     }
   }
 
@@ -186,6 +187,7 @@ function handleJavascript(fullPath, original) {
     // Print to stdout
     process.stdout.write(js);
   }
+  return true;
 }
 
 function handleDirectory(currentPath, callback) {
@@ -214,11 +216,15 @@ if (paths.length > 0) {
         if (fs.statSync(fullPath).isDirectory()) {
           handleDirectory(fullPath, function(paths) {
             _.each(paths, function(fullPath) {
-              handleJavascript(path.normalize(fullPath), fs.readFileSync(fullPath, 'utf-8'));
+              if (!handleJavascript(path.normalize(fullPath), fs.readFileSync(fullPath, 'utf-8'))) {
+                process.exitCode = -1;
+              }
             });
           });
         } else {
-          handleJavascript(fullPath, fs.readFileSync(fullPath, 'utf-8'));
+          if (!handleJavascript(fullPath, fs.readFileSync(fullPath, 'utf-8'))) {
+            process.exitCode = -1;
+          }
         }
       });
     });
@@ -233,6 +239,8 @@ if (paths.length > 0) {
     }
   });
   process.stdin.on('end', function() {
-    handleJavascript('stdin', js);
+    if (!handleJavascript('stdin', js)) {
+      process.exitCode = -1;
+    }
   });
 }


### PR DESCRIPTION
When there is an error in one of the processed files, `jsfmt` should exit with a status code other than 0.