### PR TITLE
Ignore `sourceType` property when comparing nodes.

### DIFF
--- a/lib/rewrite.js
+++ b/lib/rewrite.js
@@ -23,7 +23,7 @@ function deepomit(obj, keys) {
 }
 
 var cloneIgnoredKeys = ['parent', 'update', 'source'];
-var matchIgnoredKeys = ['type', 'prefix', 'loc', 'raw', 'range'];
+var matchIgnoredKeys = ['type', 'prefix', 'sourceType', 'loc', 'raw', 'range'];
 
 function clone(obj) {
   return JSON.parse(JSON.stringify(deepomit(obj, cloneIgnoredKeys)));


### PR DESCRIPTION
This is particularly important when you are adopting the forthcoming version of Esprima that adds `sourceType` to the `Program` node (https://github.com/jquery/esprima/issues/1159).

Without the change, the node comparison may fail and therefore some unit tests will not pass.