### PR TITLE
Do not rely on globally installed grunt-cli.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - '0.11'
   - '0.10'
-before_script:
-  - npm install -g grunt-cli
 after_script:
   - jscoverage --no-highlight lib lib-cov
   - JSFMT_COV=1 mocha -R mocha-lcov-reporter -r jscoverage --covinject=true ./tests | coveralls

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "coveralls": "~2.8.0",
     "grunt": "~0.4.5",
+    "grunt-cli": "~0.1.13",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-exec": "~0.4.5",
     "grunt-mocha-test": "~0.11.0",


### PR DESCRIPTION
Running the tests becomes very predictable: the usual `npm install && npm test`.