### PR TITLE
Fixes rewrite for es6 code

### DIFF
--- a/examples/styleGuide.js
+++ b/examples/styleGuide.js
@@ -88,8 +88,7 @@
     myVar.toString() +
     '</li>');
 
-  var myVar = new myVarTypes[
-    'A type']();
+  var myVar = new myVarTypes['A type']();
 
   callFunc(
     'An arg',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,0 +1,23 @@
+var falafel = require('falafel');
+var esprima = require('esprima');
+
+module.exports = {
+  walk: function(js, callback) {
+    return falafel(js, {
+      parser: this
+    }, function(node) {
+      // Defining the start and end is required for compatibility with falafels 'update'
+      node.start = node.range[0];
+      node.end = node.range[1];
+      return callback(node);
+    });
+  },
+  parse: function(js) {
+    return esprima.parse(js, {
+      sourceType: 'module',
+      raw: true,
+      range: true,
+      loc: true
+    });
+  }
+};

--- a/lib/rewrite.js
+++ b/lib/rewrite.js
@@ -1,9 +1,8 @@
 var util = require('util');
-var esprima = require('esprima');
-var falafel = require('falafel');
 var escodegen = require('escodegen');
 var _ = require('underscore');
 var helpers = require('./helpers');
+var parser = require('./parser');
 
 // Used to exclude circular references and functions
 function deepomit(obj, keys) {
@@ -252,18 +251,14 @@ exports.rewrite = function(js, rewriteRule) {
     return js;
   }
 
-  var parseOptions = {
-    raw: true
-  };
-  var pattern = esprima.parse(rewriteRuleParts[0], parseOptions);
-  var replacement = esprima.parse(rewriteRuleParts[1], parseOptions);
-
+  var pattern = parser.parse(rewriteRuleParts[0]);
+  var replacement = parser.parse(rewriteRuleParts[1]);
 
   var patternReplacement = unwrapNodes(pattern, replacement);
   pattern = patternReplacement[0];
   replacement = patternReplacement[1];
 
-  js = falafel(js, parseOptions, function(node) {
+  js = parser.walk(js, function(node) {
     var wildcards = {};
     if (matchNode(wildcards, pattern, node)) {
       var clonedReplacement = clone(replacement);
@@ -293,15 +288,10 @@ exports.search = function(js, searchRule) {
   // remove if one exists as the first line
   js = helpers.removeShebang(js);
 
-  var pattern = unwrapNode(esprima.parse(searchRule, {
-    raw: true
-  }));
+  var pattern = unwrapNode(parser.parse(searchRule));
 
   var matches = [];
-  falafel(js, {
-    raw: true,
-    loc: true
-  }, function(node) {
+  parser.walk(js, function(node) {
     var wildcards = {};
     if (matchNode(wildcards, pattern, node)) {
       matches.push({

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "esformatter-braces": "~1.0.0",
     "esformatter-var-each": "~1.0.0",
     "esprima": "~2.6.0",
-    "falafel": "~0.3.1",
+    "falafel": "~1.2.0",
     "glob": "~4.4.0",
     "rc": "~0.6.0",
     "rocambole": "~0.5.0",

--- a/tests/rewrite.js
+++ b/tests/rewrite.js
@@ -62,4 +62,13 @@ describe('jsfmt.rewrite', function() {
   it('should rewrite AssignmentExpression', function() {
     jsfmt.rewrite('var test = 4;', 'var a = b -> a += b').toString().should.eql('test += 4;');
   });
+
+  it('should support rewriting of es6 code', function() {
+    var source = 'import "foo"; function foo(foo, bar) {}';
+    var replacement = 'function foo(a, b) {} -> function foo(b, a) {}';
+
+    var rewritten = jsfmt.rewrite(source, replacement).toString();
+
+    rewritten.should.eql('import "foo"; function foo(bar, foo) {\n}');
+  });
 });

--- a/tests/search.js
+++ b/tests/search.js
@@ -10,6 +10,10 @@ var jsfmt = require('../' + libPath + '/index');
 describe('jsfmt.search', function() {
   it('should test basic searching', function() {
     var results = jsfmt.search('var param1 = 1, done = function(){}; _.each(param1, done);', '_.each(a, b);');
+    results[0].node.loc.should.eql({
+      start: {line: 1, column: 37},
+      end: {line: 1, column: 57}
+    });
     results[0].wildcards.a.name.should.eql('param1');
     results[0].wildcards.b.name.should.eql('done');
   });
@@ -44,14 +48,15 @@ describe('jsfmt.search', function() {
       .toString().should.eql("templates['my_key'](argA, argB)");
   });
 
-  it('should support wildcard rest params in FunctionDeclaration', function() {
-    // Can transfer arguments
+  it('should support wildcard rest params in FunctionDeclaration (transfer)', function() {
     jsfmt.rewrite('function test(argA, argB, argC) {}', 'function test(...a) {} -> function test(...a) {}')
       .toString().should.eql("function test(argA, argB, argC) {\n}");
+  });
 
-    // Can drop argument
+  it('should support wildcard rest params in FunctionDeclaration (drop) ', function() {
     jsfmt.rewrite('function test(argA, argB, argC) {}', 'function test(a, b, ...c) {} -> function test(a, b) {}')
       .toString().should.eql("function test(argA, argB) {\n}");
+
   });
 
   it('should support wildcard rest params in FunctionExpression', function() {


### PR DESCRIPTION
It looks like this issue stemmed from us using different AST parsers for different features:
  * Rewrite is using falafel, whose default is Acorn
  * Esprima is used everywhere else

This PR migrates away from Acorn for rewrite by providing an esprima parser.

This PR creates an internal interface for parsing/walking which centralises control of which parser implementation we use and how we walk the AST.