### PR TITLE
Ensure tests fail if any styles change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Use new container based infrastructure
+# http://docs.travis-ci.com/user/migrating-from-legacy/
+sudo: false
 language: node_js
 node_js:
   - 'stable'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
+  - 'stable'
+  - '4.1'
+  - '4.0'
+  - '0.12'
   - '0.11'
   - '0.10'
+  - 'iojs'
 after_script:
   - jscoverage --no-highlight lib lib-cov
   - JSFMT_COV=1 mocha -R mocha-lcov-reporter -r jscoverage --covinject=true ./tests | coveralls

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
       jsfmtLib: './bin/jsfmt -w ./lib/**/*.js',
       jsfmtTests: './bin/jsfmt -w ./tests/**/*.js',
       jsfmtGrunt: './bin/jsfmt -w ./Gruntfile.js',
-      jsfmtStyleGuide: './bin/jsfmt -w ./examples/styleGuide.js',
+      jsfmtExamples: './bin/jsfmt -w ./examples/**/*.js',
+      verifyNoChanges: 'git --no-pager diff && test "$(git diff)" == ""',
     },
   });
 
@@ -28,5 +29,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.registerTask('default', ['jshint', 'mochaTest']);
-  grunt.registerTask('fmt', ['exec']);
+  grunt.registerTask('fmt', ['exec:jsfmtLib', 'exec:jsfmtTests', 'exec:jsfmtGrunt', 'exec:jsfmtExamples']);
+  grunt.registerTask('verify', ['exec:verifyNoChanges']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
       jsfmtTests: './bin/jsfmt -w ./tests/**/*.js',
       jsfmtGrunt: './bin/jsfmt -w ./Gruntfile.js',
       jsfmtExamples: './bin/jsfmt -w ./examples/**/*.js',
-      verifyNoChanges: 'git --no-pager diff && test "$(git diff)" == ""',
+      verifyNoChanges: 'bash -c "git --no-pager diff && test \"\$(git diff)\" == \"\""',
     },
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,10 +17,15 @@ module.exports = function(grunt) {
       },
     },
     exec: {
+      // Tasks to run `jsfmt`
       jsfmtLib: './bin/jsfmt -w ./lib/**/*.js',
       jsfmtTests: './bin/jsfmt -w ./tests/**/*.js',
       jsfmtGrunt: './bin/jsfmt -w ./Gruntfile.js',
       jsfmtExamples: './bin/jsfmt -w ./examples/**/*.js',
+
+      // Task to verify there is no git diff
+      // DEV: This is best to run after `grunt fmt` to help ensure nothing changed
+      // DEV: Use `bash -c ""` to force running in `bash` on travis
       verifyNoChanges: 'bash -c "git --no-pager diff && test \"\$(git diff)\" == \"\""',
     },
   });

--- a/examples/styleGuide.js
+++ b/examples/styleGuide.js
@@ -105,11 +105,24 @@
     return;
   }
 
-  var nestedObjects = [{
+  var arrayOfObjects = [{
     a: true
   }, {
     a: false
   }];
+
+  var nestedObjects = {
+    one: {
+      fish: {
+        two: 'fish'
+      }
+    },
+    red: {
+      fish: {
+        blue: 'fish'
+      }
+    }
+  };
 
 }).call(this);
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -236,7 +236,7 @@ if (paths.length > 0) {
     var chunk = process.stdin.read();
     if (chunk !== null) {
       js += chunk;
-    } else if (chunk === null && js === ''){
+    } else if (chunk === null && js === '') {
       console.log(doc);
       process.exit(-1);
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "jsfmt": "./bin/jsfmt"
   },
   "scripts": {
-    "test": "grunt"
+    "test": "grunt && grunt fmt && grunt verify",
+    "fmt": "grunt fmt"
   },
   "files": [
     "bin",

--- a/tests/search.js
+++ b/tests/search.js
@@ -11,8 +11,14 @@ describe('jsfmt.search', function() {
   it('should test basic searching', function() {
     var results = jsfmt.search('var param1 = 1, done = function(){}; _.each(param1, done);', '_.each(a, b);');
     results[0].node.loc.should.eql({
-      start: {line: 1, column: 37},
-      end: {line: 1, column: 57}
+      start: {
+        line: 1,
+        column: 37
+      },
+      end: {
+        line: 1,
+        column: 57
+      }
     });
     results[0].wildcards.a.name.should.eql('param1');
     results[0].wildcards.b.name.should.eql('done');


### PR DESCRIPTION
We have run into a few issues before of forgetting to run `grunt fmt` on the source code before accepting pull requests. This makes it a little difficult to go back and figure out what caused the changes.

This PR will add in format checking to `npm test`, where the build will fail if any files are reported as changing after running `jsfmt`.

Summary of changes:

* Added Grunt task `verify` to run a diff on the source code
    * Ideally this is run after running `grunt fmt`
    * It will display the diff before failing
* Added `fmt` command into `package.json`
    * We can now run `npm run fmt` instead of `grunt fmt`
* Updated `.travis.yml` to include more recent versions of `node.js` and `iojs`


This pull request is expected to fail the build. It passing it dependent on #173 being merged into here. I purposely did not stack the pull requests to help verify that this build fails in travis as expected.