### PR TITLE
Add ability to disable default plugins in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ A `.jsfmtrc` will be read if it exists in any of the following directories:
 `jsfmt` will also attempt to pickup and use the configured `indent`
 variable from your `.jshintrc` configuration file, if present.
 
+#### disablePlugins
+By default `jsfmt` uses [esformatter-braces](https://github.com/pgilad/esformatter-braces) and [esformatter-var-each](https://github.com/twolfson/esformatter-var-each) plugins. However, if you would like to disable any of these, you can supply the config setting of `"disablePlugins": ["esformatter-var-each"]`.
+
 Rewriting
 ---
 
@@ -195,7 +198,7 @@ Links
 - Atom Package - https://atom.io/packages/atom-jsfmt - "Automatically run jsfmt every time you save a JavaScript source file."
 - Grunt Task - https://github.com/james2doyle/grunt-jsfmt - "A task for the jsfmt library."
 - Emacs Plugin - https://github.com/brettlangdon/jsfmt.el - "Run jsfmt from within emacs"
-- Gulp Task - https://github.com/blai/gulp-jsfmt - "A gulp task for jsfmt."  
+- Gulp Task - https://github.com/blai/gulp-jsfmt - "A gulp task for jsfmt."
 - Sublime Text plugin - https://github.com/ionutvmi/sublime-jsfmt - "On-demand and automatic jsfmt from Sublime Text 2 and 3"
 
 Changelog

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,6 @@
 var rc = require('rc');
 var deepExtend = require('deep-extend');
+var _ = require('underscore');
 
 var defaultStyle = require('./defaultStyle.json');
 
@@ -20,6 +21,11 @@ var loadConfig = function() {
   //allow overriding the list of plugins via local config
   if (config.plugins) {
     defaultStyle.plugins = config.plugins;
+  }
+
+  // Remove any default plugins if they specified them
+  if (config.disablePlugins) {
+    defaultStyle.plugins = _.difference(defaultStyle.plugins, config.disablePlugins);
   }
 
   return deepExtend(defaultStyle, config);


### PR DESCRIPTION
Potential solution for #141 

The problem is that a user wants to be able to disable one of the default plugins that we use.

This is one solution to that problem, by adding in support for a `disablePlugins` config setting which lists which of the default plugins should be disabled.

For example, having a `.jsfmtrc` file of:

```json
{
  "disablePlugins": ["esformatter-braces"]
}
```

Will make sure that `esformatter-braces` plugin is not loaded by default, like it is now.

The way this is written, this has no effect on the `plugins` config setting. Meaning, if I have the following config:

```json
{
  "disablePlugins": ["esformatter-braces"],
  "plugins": ["esformatter-braces"]
}
```

Then `esformatter-braces` *will* be loaded.