### PR TITLE
Add docs about plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ for (var i = 0; i < errors.length; i++) {
 }
 ```
 
+Plugins
+-------
+
+Since `jsfmt` uses `esformatter` under the covers for formatting your code you can utilize any `esformatter` plugins with `jsfmt`. Please see https://github.com/millermedeiros/esformatter/#plugins for more information.
+
+### JSX
+
+There exists a plugin [esformatter-jsx](https://github.com/royriojas/esformatter-jsx) which provides support for formatting JSX with `esformatter`. Please see https://github.com/royriojas/esformatter-jsx/wiki/Usage-with-jsfmt for more information on setting up with `jsfmt`.
+
 Links
 ---
 


### PR DESCRIPTION
After re-reviewing #124 it seems that there already exists a plugin for adding `jsx` support, however, we do not do a great job of showcasing that `jsfmt` supports plugins in the readme.

This PR just adds some documentation around plugins and where to find more information, as well as a link to the docs provided by @royriojas for using with `jsfmt`.